### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-dependabot.yml
+++ b/.github/workflows/test-dependabot.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test-dependabot:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/paraskuk/chatgptui/security/code-scanning/5](https://github.com/paraskuk/chatgptui/security/code-scanning/5)

To fix this issue, you should add an explicit `permissions` block to the workflow, specifying the minimal privileges required. Since the provided workflow runs on pull requests and only installs dependencies and runs code locally (no steps are shown that would require write access), the minimal permission of `contents: read` should suffice. This can be done either at the workflow root or for the individual job. Adding it at the job level (i.e., inside the `test-dependabot` job definition) closely matches the location flagged in the error report. Edit `.github/workflows/test-dependabot.yml` by inserting the following block underneath the `runs-on:` statement for the `test-dependabot` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
